### PR TITLE
Fix for make kernel headers on openSUSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ docker-compose -f docker-compose.yaml -f docker-compose.override.profiling.yaml 
 ```
 
 Caveats: You have to bear in mind that profiling tools require compiled kernel headers in order to be available in a container.
-Such headers have to be compatible with the host kernel (in the case of OSX is the kernel of `docker` VM). The above setup was tested only with `docker desktop` on `OSX`.
-It was confirmed that it is not working for example with `docker` on OpenSuse.
+Such headers have to be compatible with the host kernel (in the case of OSX is the kernel of `docker` VM). The above setup was tested only with `docker desktop` on `OSX` and with `docker` on `openSUSE Tumbleweed`.
 
 ## Building remarks
 

--- a/scripts/install-kernel-headers.sh
+++ b/scripts/install-kernel-headers.sh
@@ -5,6 +5,7 @@ KERNEL_VERSION=$(uname -r  | cut -d '-' -f 1)
 cd /tmp/linux-${KERNEL_VERSION}
 
 zcat /proc/1/root/proc/config.gz > .config
+sed -ri '/CONFIG_MODULE_SIG_KEY/s/=.+/=""/g' .config
 make all
 make modules_prepare
 make headers_install


### PR DESCRIPTION
Confirmed working:
```
 => [kernel 9/9] RUN apt install -y bpfcc-tools                                                                                                                                                                                                                                                                         19.2s
 => [kernel] exporting to image                                                                                                                                                                                                                                                                                        891.7s
 => => exporting layers                                                                                                                                                                                                                                                                                                891.6s
 => => writing image sha256:d4d6e67dff55b44d981c00154077aec661067619c1af78be29d5df309994cfda                                                                                                                                                                                                                             0.1s
 => => naming to docker.io/library/nginx-with-compiled-kernel 
```
```
[+] Running 5/5
 ✔ Container lmdb-modsecurity-perf-issue-kernel-1            Created                                                                                                                                                                                                                                                     0.8s 
 ✔ Container lmdb-modsecurity-perf-issue-base-1              Created                                                                                                                                                                                                                                                     0.0s 
 ✔ Container lmdb-modsecurity-perf-issue-dangling-backend-1  Created                                                                                                                                                                                                                                                     0.0s 
 ✔ Container lmdb-modsecurity-perf-issue-nginx-after-fix-1   Recreated                                                                                                                                                                                                                                                   1.3s 
 ✔ Container lmdb-modsecurity-perf-issue-nginx-before-fix-1  Recreated                                                                                                                                                                                                                                                   1.2s 
Attaching to base-1, dangling-backend-1, kernel-1, nginx-after-fix-1, nginx-before-fix-1
```