### PR TITLE
trace-bpfcc should be run with modsecurity 3.0.6 in nginx-before-fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ In order to compute the processing time for each request within an test that con
 Terminal one
 ```
 docker-compose exec nginx-before-fix bash
-trace-bpfcc -t  'p:/usr/local/modsecurity/lib/libmodsecurity.so.3.0.7:msc_process_request_headers "start"' 'r:/usr/local/modsecurity/lib/libmodsecurity.so.3.0.7:msc_process_request_headers "stop"' 2>/dev/null > /tmp/profiling.log
+trace-bpfcc -t  'p:/usr/local/modsecurity/lib/libmodsecurity.so.3.0.6:msc_process_request_headers "start"' 'r:/usr/local/modsecurity/lib/libmodsecurity.so.3.0.6:msc_process_request_headers "stop"' 2>/dev/null > /tmp/profiling.log
 ```
 
 In another terminal order the benchmark and wait for a results. After that stop profiling process (Ctrl+c) and compute results:


### PR DESCRIPTION
Description of the problem:
```
jan@localhost:~/lmdb-modsecurity-perf-issue> docker-compose exec nginx-before-fix bash
root@b30cfe95d09e:/tmp# trace-bpfcc -t  'p:/usr/local/modsecurity/lib/libmodsecurity.so.3.0.7:msc_process_request_headers "start"' 'r:/usr/local/modsecurity/lib/libmodsecurity.so.3.0.7:msc_process_request_headers "stop"' 2>/dev/null
could not determine address of symbol msc_process_request_headers in /usr/local/modsecurity/lib/libmodsecurity.so.3.0.7

root@b30cfe95d09e:/tmp# ls -l  /usr/local/modsecurity/lib/libmodsecurity.so.3.0.7
ls: cannot access '/usr/local/modsecurity/lib/libmodsecurity.so.3.0.7': No such file or directory

root@b30cfe95d09e:/tmp# ls -l  /usr/local/modsecurity/lib/libmodsecurity.so.3    
libmodsecurity.so.3      libmodsecurity.so.3.0.6
```